### PR TITLE
Add pointer event support for canvas

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -26,6 +26,7 @@ html, body {
   width: 100%;
   height: 100%;
   display: block;
+  touch-action: none;
 }
 #side-panel {
   width: 300px;

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -257,9 +257,9 @@ export function setupEvents() {
   });
 
   state.canvas.addEventListener('wheel', handleWheel);
-  state.canvas.addEventListener('mousedown', handleMouseDown);
-  state.canvas.addEventListener('mouseup', handleMouseUp);
-  state.canvas.addEventListener('mousemove', handleMouseMove);
+  state.canvas.addEventListener('pointerdown', handleMouseDown);
+  state.canvas.addEventListener('pointerup', handleMouseUp);
+  state.canvas.addEventListener('pointermove', handleMouseMove);
   state.canvas.addEventListener('dragover', e => e.preventDefault());
   state.canvas.addEventListener('drop', handleDrop);
 


### PR DESCRIPTION
## Summary
- use `pointerdown`, `pointermove`, and `pointerup` instead of mouse events
- disable browser gesture interactions with `touch-action: none`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840e47248848323b346da183fb6d855