### PR TITLE
Enforce unique color selection

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -1,6 +1,6 @@
 import { state, resetState } from './state.js';
 import { resizeCanvas, centerMap, draw, loadMap, updateCursor } from './canvas.js';
-import { socket } from './socketHandlers.js';
+import { socket, requestColorChange } from './socketHandlers.js';
 
 function handleMouseDown(e) {
   const rect = state.canvas.getBoundingClientRect();
@@ -300,17 +300,7 @@ export function setupEvents() {
   document.querySelectorAll('.color-swatch').forEach(swatch => {
     swatch.addEventListener('click', () => {
       const color = swatch.dataset.color;
-      const alreadySelected = swatch.classList.contains('active');
-      document.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('active'));
-      if (!alreadySelected) {
-        swatch.classList.add('active');
-        state.currentColor = color;
-      } else {
-        const redSwatch = document.querySelector('[data-color="#ff0000"]');
-        redSwatch.classList.add('active');
-        state.currentColor = '#ff0000';
-      }
-      updateCursor();
+      requestColorChange(color);
     });
   });
 

--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -4,6 +4,11 @@ import { draw, loadMap } from './canvas.js';
 const token = localStorage.getItem('authToken') || '';
 export const socket = io({ auth: { token } });
 
+// Helper to request a color change from the server
+export function requestColorChange(color) {
+  socket.emit('changeColor', color);
+}
+
 export function initSocket() {
   socket.on('stateUpdate', (serverState) => {
     state.penPaths = serverState.drawings;
@@ -26,6 +31,18 @@ export function initSocket() {
   socket.on('placeObject', (data) => {
     state.placedObjects.push(data);
     draw();
+  });
+
+  socket.on('colorAssigned', (color) => {
+    state.currentColor = color;
+    document.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('active'));
+    const swatch = document.querySelector(`[data-color="${color}"]`);
+    if (swatch) swatch.classList.add('active');
+    draw();
+  });
+
+  socket.on('colorUnavailable', (color) => {
+    alert(`Color ${color} is already in use`);
   });
 
   socket.on('mapChanged', (mapName) => {


### PR DESCRIPTION
## Summary
- add helper `requestColorChange` for socket communication
- wire client color picker to request color changes from server
- handle colorAssigned/unavailable events to update UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f83f0c3c83238ec8f00b45410852