### PR TITLE
Update sidebar cursor behavior

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -38,6 +38,7 @@ html, body {
   flex-direction: column;
   overflow-y: auto;
   user-select: none;
+  cursor: default; /* Keep default cursor inside the sidebar */
 }
 h3 {
   margin-top: 20px;

--- a/public/js/canvas.js
+++ b/public/js/canvas.js
@@ -136,8 +136,11 @@ export function updateCursor() {
     )}`;
     cursor = `url('${svgCursor}') 12 12, auto`;
   }
+  // Apply the calculated cursor only to the canvas. The sidebar and the rest
+  // of the page should keep the default cursor so that elements such as the
+  // draggable buttons can define their own cursor behaviour.
   state.canvas.style.cursor = cursor;
-  document.body.style.cursor = cursor;
+  document.body.style.cursor = 'default';
 }
 
 export function animate() {


### PR DESCRIPTION
## Summary
- force default cursor for items in sidebar
- stop setting custom cursors on the body element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68478ac7f3d48323b74841e49c44b94b