### PR TITLE
Fix color collision handling

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -1,6 +1,6 @@
 import { state, resetState } from './state.js';
 import { resizeCanvas, centerMap, draw, loadMap, updateCursor } from './canvas.js';
-import { socket } from './socketHandlers.js';
+import { socket, requestColorChange } from './socketHandlers.js';
 
 function handleMouseDown(e) {
   const rect = state.canvas.getBoundingClientRect();
@@ -300,17 +300,7 @@ export function setupEvents() {
   document.querySelectorAll('.color-swatch').forEach(swatch => {
     swatch.addEventListener('click', () => {
       const color = swatch.dataset.color;
-      const alreadySelected = swatch.classList.contains('active');
-      document.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('active'));
-      if (!alreadySelected) {
-        swatch.classList.add('active');
-        state.currentColor = color;
-      } else {
-        const redSwatch = document.querySelector('[data-color="#ff0000"]');
-        redSwatch.classList.add('active');
-        state.currentColor = '#ff0000';
-      }
-      updateCursor();
+      requestColorChange(color);
     });
   });
 

--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -4,6 +4,11 @@ import { draw, loadMap } from './canvas.js';
 const token = localStorage.getItem('authToken') || '';
 export const socket = io({ auth: { token } });
 
+// Helper to request a color change from the server
+export function requestColorChange(color) {
+  socket.emit('changeColor', color);
+}
+
 export function initSocket() {
   socket.on('stateUpdate', (serverState) => {
     state.penPaths = serverState.drawings;
@@ -26,6 +31,18 @@ export function initSocket() {
   socket.on('placeObject', (data) => {
     state.placedObjects.push(data);
     draw();
+  });
+
+  socket.on('colorAssigned', (color) => {
+    state.currentColor = color;
+    document.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('active'));
+    const swatch = document.querySelector(`[data-color="${color}"]`);
+    if (swatch) swatch.classList.add('active');
+    draw();
+  });
+
+  socket.on('colorUnavailable', (color) => {
+    alert(`Color ${color} is already in use`);
   });
 
   socket.on('mapChanged', (mapName) => {

--- a/server/userManager.js
+++ b/server/userManager.js
@@ -25,19 +25,27 @@ function changeUserColor(socketId, newColor) {
 
     if (!user) return { success: false, reason: 'User not found' };
 
-    if (newColor === 'red' || !colorsInUse[newColor]) {
+    // Normalize color string
+    const desired = typeof newColor === 'string' ? newColor.toLowerCase() : newColor;
+
+    // If the user is requesting the color they already have, allow it
+    if (desired === user.color) {
+        return { success: true, color: desired };
+    }
+
+    if (desired === 'red' || !colorsInUse[desired]) {
         // Free the user's current color if it's not red
         if (user.color !== 'red') {
             delete colorsInUse[user.color];
         }
 
         // Assign the new color
-        user.color = newColor;
-        if (newColor !== 'red') {
-            colorsInUse[newColor] = socketId;
+        user.color = desired;
+        if (desired !== 'red') {
+            colorsInUse[desired] = socketId;
         }
 
-        return { success: true, color: newColor };
+        return { success: true, color: desired };
     }
 
     return { success: false, reason: 'Color unavailable' };

--- a/test/userManager.test.js
+++ b/test/userManager.test.js
@@ -26,6 +26,18 @@ function testChangeColor() {
   userManager.removeUser('abc');
 }
 
+function testUniqueColorSelection() {
+  reset();
+  userManager.addUser('a');
+  userManager.addUser('b');
+  const r1 = userManager.changeUserColor('a', 'green');
+  assert.ok(r1.success);
+  const r2 = userManager.changeUserColor('b', 'green');
+  assert.ok(!r2.success);
+  userManager.removeUser('a');
+  userManager.removeUser('b');
+}
+
 function testRemoveUser() {
   reset();
   userManager.addUser('abc');
@@ -37,6 +49,7 @@ function testRemoveUser() {
 function run() {
   testAddAndGetUser();
   testChangeColor();
+  testUniqueColorSelection();
   testRemoveUser();
   console.log('All tests passed');
 }


### PR DESCRIPTION
## Summary
- normalize colors and allow reselecting the current color
- add unit test ensuring unique color usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f83f0c3c83238ec8f00b45410852