### PR TITLE
Ensure new clients see cleared board

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -287,6 +287,7 @@ export function setupEvents() {
   state.resetViewButton.addEventListener('click', centerMap);
 
   document.getElementById('reset-all-button').addEventListener('click', () => {
+    socket.emit('clearMap');
     resetState();
     centerMap();
     draw();

--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -52,4 +52,11 @@ export function initSocket() {
     loadMap(mapName);
     draw();
   });
+
+  socket.on('mapCleared', () => {
+    state.placedObjects = [];
+    state.penPaths = [];
+    state.pings = [];
+    draw();
+  });
 }

--- a/server/app.js
+++ b/server/app.js
@@ -63,6 +63,20 @@ function saveState() {
     }
 }
 
+function refreshState() {
+    const data = loadState();
+    state.drawings = data.drawings;
+    state.pings = data.pings;
+    state.objects = data.objects;
+    state.currentMap = data.currentMap;
+}
+
+function clearBoard() {
+    state.drawings = [];
+    state.pings = [];
+    state.objects = [];
+}
+
 function pushLimited(arr, item) {
     arr.push(item);
     if (arr.length > MAX_ITEMS) {
@@ -158,6 +172,7 @@ io.on('connection', (socket) => {
     });
 
     // Send the current state to the new client
+    refreshState();
     socket.emit('stateUpdate', state);
 
     // Handle drawing events
@@ -191,6 +206,14 @@ io.on('connection', (socket) => {
         state.pings = [];
         state.objects = [];
         io.emit('mapChanged', mapName); // Broadcast to all clients
+        saveState();
+    });
+
+    // Handle map clear events
+    socket.on('clearMap', () => {
+        clearBoard();
+        io.emit('mapCleared'); // Broadcast to all clients
+        io.emit('stateUpdate', state);
         saveState();
     });
 


### PR DESCRIPTION
## Summary
- emit `clearMap` before wiping the UI to avoid races
- centralize board clearing in `clearBoard` helper on the server
- refresh saved state for each new connection
- broadcast state after a clear so late joiners start empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68478edae75083238e671de80b8033f4