### PR TITLE
Add help overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,17 @@
         <div class="draggable-button" data-symbol="CT" title="Counter-Terrorist">CT</div>
         <div class="draggable-button" data-symbol="T" title="Terrorist">T</div>
       </div>
+      <button id="help-button" title="Help" class="help-button">Help</button>
+    </div>
+  </div>
+  <div id="help-modal">
+    <div id="help-content">
+      <h2>Board Help</h2>
+      <p><strong>Select</strong> - drag to select placed objects and press Delete to remove them.</p>
+      <p><strong>Pan</strong> - hold Ctrl or choose the hand icon to move the map.</p>
+      <p><strong>Pen</strong> - draw lines. Red lines fade after a few seconds.</p>
+      <p><strong>Ping</strong> - double click or use the ping tool to create a ping ripple.</p>
+      <button id="close-help">Close</button>
     </div>
   </div>
   <script src="/socket.io/socket.io.js"></script>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -39,6 +39,7 @@ html, body {
   overflow-y: auto;
   user-select: none;
   cursor: default; /* Keep default cursor inside the sidebar */
+  position: relative;
 }
 h3 {
   margin-top: 20px;
@@ -190,4 +191,40 @@ button.tool-button.active {
     max-height: 40vh;
     overflow-y: auto;
   }
+}
+
+/* Help button and modal */
+#help-button {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  padding: 6px 12px;
+  opacity: 0.7;
+  background-color: #ddd;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  cursor: pointer;
+}
+#help-button:hover {
+  opacity: 1;
+}
+#help-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+#help-content {
+  background-color: #fff;
+  color: #000;
+  padding: 20px;
+  border-radius: 5px;
+  width: 80%;
+  max-width: 400px;
 }

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -335,5 +335,21 @@ export function setupEvents() {
     loadMap(state.mapSelect.value);
   });
 
+  const helpButton = document.getElementById('help-button');
+  const helpModal = document.getElementById('help-modal');
+  const closeHelp = document.getElementById('close-help');
+
+  if (helpButton && helpModal && closeHelp) {
+    helpButton.addEventListener('click', () => {
+      helpModal.style.display = 'flex';
+    });
+    closeHelp.addEventListener('click', () => {
+      helpModal.style.display = 'none';
+    });
+    helpModal.addEventListener('click', (e) => {
+      if (e.target === helpModal) helpModal.style.display = 'none';
+    });
+  }
+
   setupContextMenu();
 }


### PR DESCRIPTION
## Summary
- add a help button in the sidebar and a help modal
- style help button and modal
- hook up show/hide events in the client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847901eeff483238f137a79f2bf640e