### PR TITLE
Fix red pen color sync

### DIFF
--- a/server/userManager.js
+++ b/server/userManager.js
@@ -1,8 +1,8 @@
 const users = [];
-const colorsInUse = {}; // Tracks which colors are in use (except red)
+const colorsInUse = {}; // Tracks which colors are in use (except #ff0000)
 
 function addUser(socketId) {
-    const user = { id: socketId, color: 'red' };
+    const user = { id: socketId, color: '#ff0000' };
     users.push(user);
     return user;
 }
@@ -11,7 +11,7 @@ function removeUser(socketId) {
     const userIndex = users.findIndex(u => u.id === socketId);
     if (userIndex !== -1) {
         const user = users[userIndex];
-        if (user.color !== 'red') {
+        if (user.color !== '#ff0000') {
             delete colorsInUse[user.color];
         }
         users.splice(userIndex, 1);
@@ -33,15 +33,15 @@ function changeUserColor(socketId, newColor) {
         return { success: true, color: desired };
     }
 
-    if (desired === 'red' || !colorsInUse[desired]) {
-        // Free the user's current color if it's not red
-        if (user.color !== 'red') {
+    if (desired === '#ff0000' || !colorsInUse[desired]) {
+        // Free the user's current color if it's not #ff0000
+        if (user.color !== '#ff0000') {
             delete colorsInUse[user.color];
         }
 
         // Assign the new color
         user.color = desired;
-        if (desired !== 'red') {
+        if (desired !== '#ff0000') {
             colorsInUse[desired] = socketId;
         }
 

--- a/test/userManager.test.js
+++ b/test/userManager.test.js
@@ -15,6 +15,26 @@ function testAddAndGetUser() {
   userManager.removeUser('abc');
 }
 
+function testDefaultColor() {
+  reset();
+  const u = userManager.addUser('user1');
+  assert.strictEqual(u.color, '#ff0000');
+  userManager.removeUser('user1');
+}
+
+function testMultipleRed() {
+  reset();
+  const u1 = userManager.addUser('u1');
+  const u2 = userManager.addUser('u2');
+  // second user already has red; attempt to change color back to red explicitly
+  const r = userManager.changeUserColor('u2', '#ff0000');
+  assert.ok(r.success);
+  assert.strictEqual(userManager.getUser('u1').color, '#ff0000');
+  assert.strictEqual(userManager.getUser('u2').color, '#ff0000');
+  userManager.removeUser('u1');
+  userManager.removeUser('u2');
+}
+
 function testChangeColor() {
   reset();
   userManager.addUser('abc');
@@ -48,6 +68,8 @@ function testRemoveUser() {
 
 function run() {
   testAddAndGetUser();
+  testDefaultColor();
+  testMultipleRed();
   testChangeColor();
   testUniqueColorSelection();
   testRemoveUser();


### PR DESCRIPTION
## Summary
- allow multiple users to share the default red pen colour
- keep hex code consistent for automatic fade logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847985be9048323999f8ecad95ed2c3