### PR TITLE
Fix help button overlapping at bottom

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -33,6 +33,7 @@ html, body {
   width: 300px;
   background-color: grey;
   padding: 20px;
+  padding-bottom: calc(20px + env(safe-area-inset-bottom));
   box-shadow: -2px 0 5px rgba(0,0,0,0.2);
   display: flex;
   flex-direction: column;
@@ -195,9 +196,8 @@ button.tool-button.active {
 
 /* Help button and modal */
 #help-button {
-  position: absolute;
-  bottom: 10px;
-  left: 10px;
+  margin-top: auto;
+  align-self: flex-start;
   padding: 6px 12px;
   opacity: 0.7;
   background-color: #ddd;


### PR DESCRIPTION
## Summary
- fix mobile help button layout so it doesn't overlap bottom toolbar
- add padding to side panel for mobile safe area

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68479a20d5908323b974b6547b69b10f