### PR TITLE
Fix mobile panel height

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -189,8 +189,9 @@ button.tool-button.active {
   #side-panel {
     order: 2;
     width: 100%;
-    max-height: 40vh;
+    max-height: 60vh;
     overflow-y: auto;
+    padding-bottom: calc(80px + env(safe-area-inset-bottom));
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure side panel isn't hidden by mobile browser controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68479b90205c83239c7c068f4bbba948