### PR TITLE
Add mobile-friendly object deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tacticalMap
 - **Map Selection** – Choose between several stock CS2 maps.
 - **Drawing Tools** – Freehand pen drawing with colour selection.
 - **Ping and Draggable Objects** – Double click or use the ping tool to highlight points. Drag icons (e.g. grenade, CT, T) onto the map.
-- **Object Selection** – Select placed objects to move or delete them.
+- **Object Selection** – Select placed objects to move or delete them. A Delete button allows removal on mobile devices.
 - **Pan and Zoom** – Scroll to zoom and drag to pan the map.
 - **Context Menu** – Right click the canvas to quickly switch tools.
 - **Real‑Time Collaboration** – All drawings, pings and objects are synced between connected clients.

--- a/index.html
+++ b/index.html
@@ -59,13 +59,14 @@
         <div class="draggable-button" data-symbol="CT" title="Counter-Terrorist">CT</div>
         <div class="draggable-button" data-symbol="T" title="Terrorist">T</div>
       </div>
+      <button id="delete-objects-button" class="action-button">Delete Selected</button>
       <button id="help-button" title="Help" class="help-button">Help</button>
     </div>
   </div>
   <div id="help-modal">
     <div id="help-content">
       <h2>Board Help</h2>
-      <p><strong>Select</strong> - drag to select placed objects and press Delete to remove them.</p>
+      <p><strong>Select</strong> - drag to select placed objects then press Delete or tap the Delete button to remove them.</p>
       <p><strong>Pan</strong> - hold Ctrl or choose the hand icon to move the map.</p>
       <p><strong>Pen</strong> - draw lines. Red lines fade after a few seconds.</p>
       <p><strong>Ping</strong> - double click or use the ping tool to create a ping ripple.</p>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -66,6 +66,20 @@ button.map-button {
 button.map-button:hover {
   background-color: #ccc;
 }
+button.action-button {
+  width: 100%;
+  height: 40px;
+  font-size: 14px;
+  margin-top: 10px;
+  background-color: #ddd;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  cursor: pointer;
+  display: none;
+}
+button.action-button:hover {
+  background-color: #ccc;
+}
 button.tool-button {
   width: 40px;
   height: 40px;


### PR DESCRIPTION
## Summary
- add Delete Selected button for removing objects on touch devices
- hide or show the new button depending on selection
- wire up removal logic to the new button
- document the new mobile delete option

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68479f4dad3c8323aedf944a63990128