### PR TITLE
Add text tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ tacticalMap
 - **Map Selection** – Choose between several stock CS2 maps.
 - **Drawing Tools** – Freehand pen drawing with colour selection.
 - **Ping and Draggable Objects** – Double click or use the ping tool to highlight points. Drag icons (e.g. grenade, CT, T) onto the map. On touch screens press and hold an icon to drag it, or tap the icon then tap the map to place it.
+- **Text Boxes** – Use the text tool to drop editable notes directly onto the canvas. Double click any text to edit it again.
 - **Object Selection** – Select placed objects to move or delete them. A Delete button allows removal on mobile devices.
 - **Pan and Zoom** – Scroll to zoom and drag to pan the map.
 - **Context Menu** – Right click the canvas to quickly switch tools.

--- a/index.html
+++ b/index.html
@@ -43,8 +43,6 @@
         <button class="tool-button" data-tool="select" title="Select Tool">🖱️</button>
         <button class="tool-button" data-tool="pan" title="Pan Tool">🖐️</button>
         <button class="tool-button" data-tool="pen" title="Pen Tool">✏️</button>
-        <button class="tool-button" data-tool="line" title="Line Tool">📏</button>
-        <button class="tool-button" data-tool="arrow" title="Arrow Tool">➡️</button>
         <button class="tool-button" data-tool="text" title="Text Tool">🔤</button>
         <button class="tool-button" data-tool="ping" title="Ping Tool">📍</button>
       </div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -118,6 +118,18 @@ button.tool-button.active {
 .draggable-button:active {
   cursor: grabbing;
 }
+.text-editor {
+  position: absolute;
+  min-width: 100px;
+  min-height: 30px;
+  font-size: 16px;
+  padding: 2px;
+  border: 1px solid #888;
+  border-radius: 3px;
+  resize: none;
+  z-index: 1500;
+}
+
 .draggable-container {
   display: flex;
   flex-wrap: wrap;

--- a/public/js/canvas.js
+++ b/public/js/canvas.js
@@ -130,6 +130,8 @@ export function updateCursor() {
     cursor = 'grab';
   } else if (state.currentTool === 'select') {
     cursor = 'default';
+  } else if (state.currentTool === 'text') {
+    cursor = 'text';
   } else if (state.currentTool && state.currentColor) {
     const svgCursor = `data:image/svg+xml;base64,${btoa(
       `<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24'><circle cx='12' cy='12' r='6' fill='${state.currentColor}'/></svg>`

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -9,6 +9,58 @@ function updateDeleteButtonVisibility() {
   deleteButton.style.display = state.selectedObjectIndices.length > 0 ? 'block' : 'none';
 }
 
+function closeTextEditor(save) {
+  if (!state.activeTextInput) return;
+  const input = state.activeTextInput;
+  const index = state.editingObjectIndex;
+  const text = input.value.trim();
+  const x = (parseFloat(input.style.left) - state.offsetX) / state.scale;
+  const y = (parseFloat(input.style.top) - state.offsetY) / state.scale;
+  input.remove();
+  state.activeTextInput = null;
+  state.editingObjectIndex = null;
+  if (save && text) {
+    if (index !== null) {
+      state.placedObjects[index].symbol = text;
+      state.placedObjects[index].type = 'text';
+      socket.emit('editObject', { index, symbol: text, type: 'text' });
+    } else {
+      const data = { symbol: text, x, y, type: 'text' };
+      state.placedObjects.push(data);
+      socket.emit('placeObject', data);
+    }
+  } else if (index !== null && !text) {
+    socket.emit('removeObjects', [index]);
+    state.placedObjects.splice(index, 1);
+  }
+  draw();
+  updateDeleteButtonVisibility();
+}
+
+function openTextEditor(x, y, index = null) {
+  const container = document.getElementById('canvas-container');
+  closeTextEditor(false);
+  const input = document.createElement('textarea');
+  input.className = 'text-editor';
+  if (index !== null) input.value = state.placedObjects[index].symbol;
+  input.style.left = `${state.offsetX + x * state.scale}px`;
+  input.style.top = `${state.offsetY + y * state.scale}px`;
+  container.appendChild(input);
+  input.focus();
+  state.activeTextInput = input;
+  state.editingObjectIndex = index;
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      closeTextEditor(true);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeTextEditor(false);
+    }
+  });
+  input.addEventListener('blur', () => closeTextEditor(true));
+}
+
 function handlePointerDown(e) {
   if (state.draggedSymbol) {
     // When an object icon is selected, ignore tool interactions
@@ -69,6 +121,11 @@ function handlePointerDown(e) {
     state.isDrawing = true;
     state.isLiveDrawing = true;
     state.penPath = [{ x, y }];
+    return;
+  }
+
+  if (state.currentTool === 'text' && e.button === 0) {
+    openTextEditor(x, y);
     return;
   }
 
@@ -223,6 +280,15 @@ function handleDoubleClick(e) {
   const rect = state.canvas.getBoundingClientRect();
   const x = (e.clientX - rect.left - state.offsetX) / state.scale;
   const y = (e.clientY - rect.top - state.offsetY) / state.scale;
+  const idx = state.placedObjects.findIndex(obj => {
+    const dx = x - obj.x;
+    const dy = y - obj.y;
+    return Math.sqrt(dx * dx + dy * dy) < 20 / state.scale && obj.type === 'text';
+  });
+  if (idx !== -1) {
+    openTextEditor(state.placedObjects[idx].x, state.placedObjects[idx].y, idx);
+    return;
+  }
   const ping = {
     x,
     y,
@@ -242,7 +308,7 @@ function placeDraggedObject(e) {
   const rect = state.canvas.getBoundingClientRect();
   const x = (e.clientX - rect.left - state.offsetX) / state.scale;
   const y = (e.clientY - rect.top - state.offsetY) / state.scale;
-  const data = { symbol: state.draggedSymbol, x, y };
+  const data = { symbol: state.draggedSymbol, x, y, type: 'symbol' };
   state.placedObjects.push(data);
   socket.emit('placeObject', data);
   state.draggedSymbol = null;

--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -52,6 +52,14 @@ export function initSocket() {
     draw();
   });
 
+  socket.on('editObject', (data) => {
+    if (state.placedObjects[data.index]) {
+      state.placedObjects[data.index].symbol = data.symbol;
+      if (data.type) state.placedObjects[data.index].type = data.type;
+      draw();
+    }
+  });
+
   socket.on('colorAssigned', (color) => {
     state.currentColor = color;
     document.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('active'));

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -25,7 +25,9 @@ export const state = {
   isPinching: false,
   initialPinchDistance: 0,
   initialScale: 1,
-  initialWorldCenter: { x: 0, y: 0 }
+  initialWorldCenter: { x: 0, y: 0 },
+  activeTextInput: null,
+  editingObjectIndex: null
 };
 
 state.ctx = state.canvas.getContext('2d');
@@ -53,6 +55,8 @@ export function resetState() {
   state.initialPinchDistance = 0;
   state.initialScale = 1;
   state.initialWorldCenter = { x: 0, y: 0 };
+  state.activeTextInput = null;
+  state.editingObjectIndex = null;
 }
 
 export function clearBoardState() {
@@ -65,4 +69,6 @@ export function clearBoardState() {
   state.isLiveDrawing = false;
   state.pings.length = 0;
   state.draggedSymbol = null;
+  state.activeTextInput = null;
+  state.editingObjectIndex = null;
 }


### PR DESCRIPTION
## Summary
- add editable text tool for notes
- remove unused line and arrow buttons
- support editing of text objects on double click
- sync text edits through new `editObject` socket message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847da5f5688832393b084bbc7780a4d