### PR TITLE
Fix collapsed sidebar UI gaps and context tool sync

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -79,7 +79,7 @@ html, body {
   flex-direction: column;
   align-items: center;
   gap: 5px;
-  margin-top: 45px;
+  margin-top: 25px;
   margin-bottom: 10px;
 }
 

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -428,6 +428,7 @@ function setupContextMenu() {
     if (selectToolButton) selectToolButton.classList.add('active');
     state.currentTool = 'select';
     updateCursor();
+    updateCollapsedUI();
     customMenu.style.display = 'none';
   });
 
@@ -437,6 +438,7 @@ function setupContextMenu() {
     if (panToolButton) panToolButton.classList.add('active');
     state.currentTool = 'pan';
     updateCursor();
+    updateCollapsedUI();
     customMenu.style.display = 'none';
   });
 
@@ -446,6 +448,7 @@ function setupContextMenu() {
     if (penToolButton) penToolButton.classList.add('active');
     state.currentTool = 'pen';
     updateCursor();
+    updateCollapsedUI();
     customMenu.style.display = 'none';
   });
 }


### PR DESCRIPTION
## Summary
- reduce gap between color swatch and collapse button when sidebar is collapsed
- update collapsed tool display when switching tools via the context menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847e0e7ac50832393b4053916ae3e29