### PR TITLE
Add username fields and join screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,13 @@
   <link rel="stylesheet" href="css/style.css"> <!-- Link to external CSS -->
 </head>
 <body>
+  <div id="join-screen">
+    <div id="join-content">
+      <label>Name: <input id="name-input" type="text" /></label>
+      <label>Room: <input id="room-input" type="text" /></label>
+      <button id="join-button">Join</button>
+    </div>
+  </div>
   <div id="main">
     <div id="canvas-container">
       <canvas id="mapCanvas"></canvas>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -319,3 +319,25 @@ button.tool-button.active {
   width: 80%;
   max-width: 400px;
 }
+
+#join-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 3000;
+}
+
+#join-content {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,14 +2,31 @@ import { animate } from './canvas.js';
 import { setupEvents } from './events.js';
 import { initSocket } from './socketHandlers.js';
 
-if (document.readyState === 'loading') {
-  window.addEventListener('DOMContentLoaded', () => {
-    setupEvents();
-    initSocket();
-    animate();
-  });
-} else {
+function startBoard(name, room) {
   setupEvents();
-  initSocket();
+  initSocket(name, room);
   animate();
+}
+
+function start() {
+  const joinBtn = document.getElementById('join-button');
+  if (joinBtn) {
+    joinBtn.addEventListener('click', () => {
+      const name = document.getElementById('name-input').value.trim();
+      if (!name) return alert('Please enter a name');
+      const room = document.getElementById('room-input').value.trim();
+      startBoard(name, room);
+      const joinScreen = document.getElementById('join-screen');
+      if (joinScreen) joinScreen.style.display = 'none';
+    });
+  } else {
+    // Fallback if join screen is missing
+    startBoard('', '');
+  }
+}
+
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', start);
+} else {
+  start();
 }

--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -1,15 +1,14 @@
 import { state } from './state.js';
 import { draw, loadMap } from './canvas.js';
 
-const token = localStorage.getItem('authToken') || '';
-export const socket = io({ auth: { token } });
+export let socket;
 
 // Helper to request a color change from the server
 export function requestColorChange(color) {
-  socket.emit('changeColor', color);
+  if (socket) socket.emit('changeColor', color);
 }
 
-export function initSocket() {
+function attachHandlers() {
   socket.on('stateUpdate', (serverState) => {
     state.penPaths = serverState.drawings;
     state.pings = serverState.pings;
@@ -87,4 +86,18 @@ export function initSocket() {
     state.pings = [];
     draw();
   });
+
+  socket.on('userConnected', (data) => {
+    console.log(`${data.name || 'Unknown'} joined`);
+  });
+
+  socket.on('userDisconnected', (data) => {
+    console.log(`${data.name || 'Unknown'} left`);
+  });
+}
+
+export function initSocket(name, room) {
+  const token = localStorage.getItem('authToken') || '';
+  socket = io({ auth: { token, name, room } });
+  attachHandlers();
 }

--- a/server/app.js
+++ b/server/app.js
@@ -172,10 +172,13 @@ app.get('/', (req, res) => {
 io.on('connection', (socket) => {
     console.log('A user connected:', socket.id);
 
+    const { name = '', room = '' } = socket.handshake.auth || {};
+
     // Add the user and assign a color
-    const user = userManager.addUser(socket.id);
+    const user = userManager.addUser(socket.id, name);
+    if (room) socket.join(room);
     socket.emit('colorAssigned', user.color);
-    socket.broadcast.emit('userConnected', socket.id);
+    socket.broadcast.emit('userConnected', { id: socket.id, name });
 
     // Handle color change requests
     socket.on('changeColor', (newColor) => {
@@ -275,8 +278,8 @@ io.on('connection', (socket) => {
     // Handle disconnection
     socket.on('disconnect', () => {
         console.log('A user disconnected:', socket.id);
-        userManager.removeUser(socket.id);
-        socket.broadcast.emit('userDisconnected', socket.id);
+        const user = userManager.removeUser(socket.id);
+        socket.broadcast.emit('userDisconnected', { id: socket.id, name: user ? user.name : '' });
     });
 });
 

--- a/server/userManager.js
+++ b/server/userManager.js
@@ -1,8 +1,8 @@
 const users = [];
 const colorsInUse = {}; // Tracks which colors are in use (except #ff0000)
 
-function addUser(socketId) {
-    const user = { id: socketId, color: '#ff0000' };
+function addUser(socketId, name = '') {
+    const user = { id: socketId, color: '#ff0000', name };
     users.push(user);
     return user;
 }
@@ -51,6 +51,13 @@ function changeUserColor(socketId, newColor) {
     return { success: false, reason: 'Color unavailable' };
 }
 
+function setUserName(socketId, name) {
+    const user = users.find(u => u.id === socketId);
+    if (!user) return false;
+    user.name = name;
+    return true;
+}
+
 function getUser(socketId) {
     return users.find(u => u.id === socketId) || null;
 }
@@ -63,6 +70,7 @@ module.exports = {
     addUser,
     removeUser,
     changeUserColor,
+    setUserName,
     getUser,
     getAllUsers,
 };

--- a/test/userManager.test.js
+++ b/test/userManager.test.js
@@ -8,10 +8,12 @@ function reset() {
 
 function testAddAndGetUser() {
   reset();
-  const u = userManager.addUser('abc');
+  const u = userManager.addUser('abc', 'Alice');
   assert.strictEqual(u.id, 'abc');
+  assert.strictEqual(u.name, 'Alice');
   const fetched = userManager.getUser('abc');
   assert.strictEqual(fetched.id, 'abc');
+  assert.strictEqual(fetched.name, 'Alice');
   userManager.removeUser('abc');
 }
 
@@ -66,6 +68,15 @@ function testRemoveUser() {
   assert.strictEqual(userManager.getUser('abc'), null);
 }
 
+function testSetUserName() {
+  reset();
+  userManager.addUser('id1');
+  userManager.setUserName('id1', 'Bob');
+  const user = userManager.getUser('id1');
+  assert.strictEqual(user.name, 'Bob');
+  userManager.removeUser('id1');
+}
+
 function run() {
   testAddAndGetUser();
   testDefaultColor();
@@ -73,6 +84,7 @@ function run() {
   testChangeColor();
   testUniqueColorSelection();
   testRemoveUser();
+  testSetUserName();
   console.log('All tests passed');
 }
 


### PR DESCRIPTION
## Summary
- extend user manager to track a name for each user
- allow joining with a name/room via Socket.IO
- broadcast names on connect/disconnect
- add join screen that collects name before enabling board interaction
- initialize board only after join event
- update tests for new user name functionality

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847e32ca76c8323b7599c9c6d72aa8c