### PR TITLE
Add username feature

### DIFF
--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -4,7 +4,12 @@ import { draw, loadMap } from './canvas.js';
 const token = localStorage.getItem('authToken') || '';
 const params = new URLSearchParams(window.location.search);
 const room = params.get('room') || '';
-export const socket = io({ auth: { token }, query: { room } });
+let name = params.get('name') || '';
+while (!name.trim()) {
+  name = prompt('Enter your name:') || '';
+  name = name.trim();
+}
+export const socket = io({ auth: { token }, query: { room, name } });
 
 // Helper to request a color change from the server
 export function requestColorChange(color) {
@@ -88,5 +93,13 @@ export function initSocket() {
     state.penPaths = [];
     state.pings = [];
     draw();
+  });
+
+  socket.on('userConnected', (u) => {
+    if (u && u.name) console.log(`${u.name} joined`);
+  });
+
+  socket.on('userDisconnected', (u) => {
+    if (u && u.name) console.log(`${u.name} left`);
   });
 }

--- a/public/landing.html
+++ b/public/landing.html
@@ -26,14 +26,19 @@
   </div>
   <script>
     const nameInput = document.getElementById('name');
+    function getName() {
+      return nameInput.value.trim();
+    }
     document.getElementById('host-btn').addEventListener('click', () => {
-      const name = encodeURIComponent(nameInput.value.trim());
-      window.location.href = `board.html?name=${name}&host=1`;
+      const name = getName();
+      if (!name) return alert('Please enter your name');
+      window.location.href = `board.html?name=${encodeURIComponent(name)}&host=1`;
     });
     document.getElementById('join-btn').addEventListener('click', () => {
-      const name = encodeURIComponent(nameInput.value.trim());
+      const name = getName();
+      if (!name) return alert('Please enter your name');
       const room = encodeURIComponent(document.getElementById('room').value.trim());
-      window.location.href = `board.html?name=${name}&room=${room}`;
+      window.location.href = `board.html?name=${encodeURIComponent(name)}&room=${room}`;
     });
   </script>
 </body>

--- a/server/app.js
+++ b/server/app.js
@@ -196,6 +196,7 @@ io.on('connection', (socket) => {
     console.log('A user connected:', socket.id);
 
     const roomCode = socket.handshake.query.room;
+    const userName = socket.handshake.query.name || '';
     if (!roomCode || !rooms.has(roomCode)) {
         socket.emit('invalidRoom');
         return socket.disconnect(true);
@@ -205,9 +206,9 @@ io.on('connection', (socket) => {
     const roomState = rooms.get(roomCode);
 
     // Add the user and assign a color
-    const user = userManager.addUser(socket.id);
+    const user = userManager.addUser(socket.id, userName);
     socket.emit('colorAssigned', user.color);
-    socket.broadcast.to(roomCode).emit('userConnected', socket.id);
+    socket.broadcast.to(roomCode).emit('userConnected', { id: socket.id, name: userName });
 
     // Handle color change requests
     socket.on('changeColor', (newColor) => {
@@ -301,8 +302,9 @@ io.on('connection', (socket) => {
     // Handle disconnection
     socket.on('disconnect', () => {
         console.log('A user disconnected:', socket.id);
-        userManager.removeUser(socket.id);
-        socket.broadcast.to(roomCode).emit('userDisconnected', socket.id);
+        const removed = userManager.removeUser(socket.id);
+        const name = removed ? removed.name : '';
+        socket.broadcast.to(roomCode).emit('userDisconnected', { id: socket.id, name });
     });
 });
 

--- a/server/userManager.js
+++ b/server/userManager.js
@@ -1,8 +1,8 @@
 const users = [];
 const colorsInUse = {}; // Tracks which colors are in use (except #ff0000)
 
-function addUser(socketId) {
-    const user = { id: socketId, color: '#ff0000' };
+function addUser(socketId, name = '') {
+    const user = { id: socketId, color: '#ff0000', name };
     users.push(user);
     return user;
 }
@@ -51,6 +51,15 @@ function changeUserColor(socketId, newColor) {
     return { success: false, reason: 'Color unavailable' };
 }
 
+function setUserName(socketId, name) {
+    const user = users.find(u => u.id === socketId);
+    if (user) {
+        user.name = name;
+        return true;
+    }
+    return false;
+}
+
 function getUser(socketId) {
     return users.find(u => u.id === socketId) || null;
 }
@@ -63,6 +72,7 @@ module.exports = {
     addUser,
     removeUser,
     changeUserColor,
+    setUserName,
     getUser,
     getAllUsers,
 };

--- a/test/userManager.test.js
+++ b/test/userManager.test.js
@@ -8,24 +8,26 @@ function reset() {
 
 function testAddAndGetUser() {
   reset();
-  const u = userManager.addUser('abc');
+  const u = userManager.addUser('abc', 'Alice');
   assert.strictEqual(u.id, 'abc');
+  assert.strictEqual(u.name, 'Alice');
   const fetched = userManager.getUser('abc');
   assert.strictEqual(fetched.id, 'abc');
+  assert.strictEqual(fetched.name, 'Alice');
   userManager.removeUser('abc');
 }
 
 function testDefaultColor() {
   reset();
-  const u = userManager.addUser('user1');
+  const u = userManager.addUser('user1', 'Bob');
   assert.strictEqual(u.color, '#ff0000');
   userManager.removeUser('user1');
 }
 
 function testMultipleRed() {
   reset();
-  const u1 = userManager.addUser('u1');
-  const u2 = userManager.addUser('u2');
+  const u1 = userManager.addUser('u1', 'A');
+  const u2 = userManager.addUser('u2', 'B');
   // second user already has red; attempt to change color back to red explicitly
   const r = userManager.changeUserColor('u2', '#ff0000');
   assert.ok(r.success);
@@ -37,7 +39,7 @@ function testMultipleRed() {
 
 function testChangeColor() {
   reset();
-  userManager.addUser('abc');
+  userManager.addUser('abc', 'C');
   const result = userManager.changeUserColor('abc', 'blue');
   assert.ok(result.success);
   assert.strictEqual(result.color, 'blue');
@@ -48,8 +50,8 @@ function testChangeColor() {
 
 function testUniqueColorSelection() {
   reset();
-  userManager.addUser('a');
-  userManager.addUser('b');
+  userManager.addUser('a', 'A');
+  userManager.addUser('b', 'B');
   const r1 = userManager.changeUserColor('a', 'green');
   assert.ok(r1.success);
   const r2 = userManager.changeUserColor('b', 'green');
@@ -60,7 +62,7 @@ function testUniqueColorSelection() {
 
 function testRemoveUser() {
   reset();
-  userManager.addUser('abc');
+  userManager.addUser('abc', 'Z');
   const removed = userManager.removeUser('abc');
   assert.ok(removed);
   assert.strictEqual(userManager.getUser('abc'), null);


### PR DESCRIPTION
## Summary
- support usernames server side
- allow clients to specify a name on connection
- block board until a name is supplied
- announce user join/leave with names
- update tests for new userManager functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847e7fd8f68832380264db3dc88b821