### PR TITLE
Fix host redirect issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ tacticalMap
 
 ### Hosting Rooms
 Create a new board by sending a `POST` request to `/host`. The response contains
-a `code` that other clients can use to join. Open `board.html?room=<code>` (or
-`index.html?room=<code>`) to connect to that room and share the board state.
+a `code` that other clients can use to join. Open `board.html?room=<code>` to
+connect to that room and share the board state.
 
 ### Environment Variables
 Set the following variables in a `.env` file or your environment:

--- a/server/app.js
+++ b/server/app.js
@@ -188,7 +188,7 @@ app.post('/host', (req, res) => {
 
 // Serve board page directly if requested
 app.get('/board.html', (req, res) => {
-    res.sendFile(path.join(__dirname, '../index.html'));
+    res.sendFile(path.join(__dirname, '../public/board.html'));
 });
 
 // Handle WebSocket connections


### PR DESCRIPTION
## Summary
- fix server route for serving board page
- update README instructions for opening hosted boards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847ebbe53748323881873abe1e2d06e