### PR TITLE
Add client handler for invalid room event

### DIFF
--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -102,4 +102,9 @@ export function initSocket() {
   socket.on('userDisconnected', (u) => {
     if (u && u.name) console.log(`${u.name} left`);
   });
+
+  socket.on('invalidRoom', () => {
+    alert('Invalid room code');
+    window.location.href = '/?invalidRoom=1';
+  });
 }

--- a/public/landing.html
+++ b/public/landing.html
@@ -25,6 +25,10 @@
     </div>
   </div>
   <script>
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('invalidRoom') === '1') {
+      alert('Invalid room code');
+    }
     const nameInput = document.getElementById('name');
     function getName() {
       return nameInput.value.trim();


### PR DESCRIPTION
## Summary
- handle `invalidRoom` event in `socketHandlers.js`
- forward user to landing page and show alert when invalid room code is used
- display any `invalidRoom` query flag on the landing page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847ed36c1948323b451b3696ba3974e