### PR TITLE
Update default CORS origin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ a `code` that other clients can use to join. Open `board.html?room=<code>` to
 connect to that room and share the board state.
 
 ### Environment Variables
-Set the following variables in a `.env` file or your environment:
-- `ALLOWED_ORIGIN` – Allowed CORS origin (`https://localhost:3000` by default).
+-Set the following variables in a `.env` file or your environment:
+- `ALLOWED_ORIGIN` – Allowed CORS origin (`http://tacmap.xyz` by default).
 - `AUTH_TOKEN` – Require clients to provide this token when connecting.
 - `SSL_KEY_PATH` and `SSL_CERT_PATH` – Enable HTTPS by providing paths to a certificate and key.
 


### PR DESCRIPTION
## Summary
- fix default origin URL in Environment Variables section of README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684802ecaff083239aff3caa5e88c9e8