### PR TITLE
Fix rate-limit memory leak on disconnect

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -305,6 +305,7 @@ io.on('connection', (socket) => {
         const removed = userManager.removeUser(socket.id);
         const name = removed ? removed.name : '';
         socket.broadcast.to(roomCode).emit('userDisconnected', { id: socket.id, name });
+        lastEvent.delete(socket.id);
     });
 });
 


### PR DESCRIPTION
## Summary
- remove socket's last event data when it disconnects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684802ef4cf88323a85c8ba36d758874