### PR TITLE
Fix repeated invalid code alert

### DIFF
--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -1,6 +1,10 @@
 const urlParams = new URLSearchParams(window.location.search);
 if (urlParams.get('invalidRoom') === '1') {
   alert('Invalid room code');
+  // remove the query parameter so the alert doesn't keep showing
+  urlParams.delete('invalidRoom');
+  const newUrl = window.location.pathname + (urlParams.toString() ? '?' + urlParams.toString() : '');
+  window.history.replaceState({}, '', newUrl);
 }
 
 const header = document.getElementById('button-container');


### PR DESCRIPTION
## Summary
- clear `invalidRoom` query parameter from `landing.js` after showing alert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684816ea968c8323bea6f42f091caeef