### PR TITLE
Remove close button from help modal

### DIFF
--- a/public/board.html
+++ b/public/board.html
@@ -81,7 +81,6 @@
       <p><strong>Pen</strong> - draw lines. Red lines fade after a few seconds.</p>
       <p><strong>Ping</strong> - double click or use the ping tool to create a ping ripple.</p>
       <p><strong>Objects</strong> - press and hold an icon to drag it onto the map. On touch screens you can also tap an icon, then tap the map to place it.</p>
-      <button id="close-help">Close</button>
     </div>
   </div>
   <script src="/socket.io/socket.io.js"></script>

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -616,14 +616,10 @@ export function setupEvents() {
 
   const helpButton = document.getElementById('help-button');
   const helpModal = document.getElementById('help-modal');
-  const closeHelp = document.getElementById('close-help');
 
-  if (helpButton && helpModal && closeHelp) {
+  if (helpButton && helpModal) {
     helpButton.addEventListener('click', () => {
       helpModal.style.display = 'flex';
-    });
-    closeHelp.addEventListener('click', () => {
-      helpModal.style.display = 'none';
     });
     helpModal.addEventListener('click', (e) => {
       if (e.target === helpModal) helpModal.style.display = 'none';


### PR DESCRIPTION
## Summary
- tidy up the help modal by removing the Close button
- simplify events.js accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68481d595cd88323a0bebd10e4893384