### PR TITLE
Add awp and anchor draggable objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tacticalMap
 ## Current Features
 - **Map Selection** – Choose between several stock CS2 maps.
 - **Drawing Tools** – Freehand pen drawing with colour selection.
-- **Ping and Draggable Objects** – Double click or use the ping tool to highlight points. Drag icons (e.g. grenade, CT, T) onto the map. On touch screens press and hold an icon to drag it, or tap the icon then tap the map to place it.
+ - **Ping and Draggable Objects** – Double click or use the ping tool to highlight points. Drag icons (e.g. grenade, AWP, anchor, CT, T) onto the map. On touch screens press and hold an icon to drag it, or tap the icon then tap the map to place it.
 - **Text Boxes** – Use the text tool to drop editable notes directly onto the canvas. Double click (or double tap on mobile) any text to edit it again.
 - **Object Selection** – Select placed objects to move or delete them. A Delete button allows removal on mobile devices.
 - **Pan and Zoom** – Scroll to zoom and drag to pan the map.

--- a/public/board.html
+++ b/public/board.html
@@ -55,16 +55,18 @@
         <button class="tool-button" data-tool="ping" title="Ping Tool">📍</button>
       </div>
       <h3>Draggable Objects</h3>
-      <div class="draggable-container">
-        <!-- Ensure draggable objects match the JavaScript logic -->
-        <div class="draggable-button" data-symbol="💥" title="Flash">💥</div>
-        <div class="draggable-button" data-symbol="💣" title="Bomb">💣</div>
-        <div class="draggable-button" data-symbol="🔥" title="Molotov">🔥</div>
-        <div class="draggable-button" data-symbol="💨" title="Smoke">💨</div>
-        <div class="draggable-button" data-symbol="🎯" title="Decoy">🎯</div>
-        <div class="draggable-button" data-symbol="CT" title="Counter-Terrorist">CT</div>
-        <div class="draggable-button" data-symbol="T" title="Terrorist">T</div>
-      </div>
+        <div class="draggable-container">
+          <!-- Ensure draggable objects match the JavaScript logic -->
+          <div class="draggable-button" data-symbol="💥" title="Flash">💥</div>
+          <div class="draggable-button" data-symbol="💣" title="Bomb">💣</div>
+          <div class="draggable-button" data-symbol="🔥" title="Molotov">🔥</div>
+          <div class="draggable-button" data-symbol="💨" title="Smoke">💨</div>
+          <div class="draggable-button" data-symbol="🎯" title="Decoy">🎯</div>
+          <div class="draggable-button" data-symbol="🔫" title="AWP">🔫</div>
+          <div class="draggable-button" data-symbol="⚓" title="Anchor">⚓</div>
+          <div class="draggable-button" data-symbol="CT" title="Counter-Terrorist">CT</div>
+          <div class="draggable-button" data-symbol="T" title="Terrorist">T</div>
+        </div>
       <button id="delete-objects-button" class="action-button">Delete Selected</button>
       <div id="user-list">
         <h4>Members</h4>


### PR DESCRIPTION
## Summary
- add AWP and anchor buttons to the draggable object list
- document the new draggable icons in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848201e90d483238d5a4c6e94e2d4f8