### PR TITLE
Enable closing host/join forms

### DIFF
--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -21,7 +21,22 @@ const joinBtn = document.getElementById('join-btn');
 const hostForm = document.getElementById('host-form');
 const joinForm = document.getElementById('join-form');
 
+let activeForm = null;
+
+function hideForms() {
+  hostBtn.classList.remove('active');
+  joinBtn.classList.remove('active');
+  hostForm.classList.remove('show');
+  joinForm.classList.remove('show');
+  activeForm = null;
+}
+
 function toggleForm(type) {
+  if (activeForm === type) {
+    hideForms();
+    return;
+  }
+  activeForm = type;
   if (type === 'host') {
     hostBtn.classList.add('active');
     joinBtn.classList.remove('active');
@@ -59,3 +74,15 @@ hostBtn.addEventListener('click', () => toggleForm('host'));
 joinBtn.addEventListener('click', () => toggleForm('join'));
 document.getElementById('host-confirm').addEventListener('click', hostRoom);
 document.getElementById('join-confirm').addEventListener('click', joinRoom);
+
+document.addEventListener('click', (e) => {
+  if (
+    activeForm &&
+    !hostBtn.contains(e.target) &&
+    !joinBtn.contains(e.target) &&
+    !hostForm.contains(e.target) &&
+    !joinForm.contains(e.target)
+  ) {
+    hideForms();
+  }
+});


### PR DESCRIPTION
## Summary
- allow host/join forms on landing page to be dismissed
- clicking the same button again or clicking outside closes the forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848213dde4883239639c718dab8b8f6