### PR TITLE
Add board image export

### DIFF
--- a/public/board.html
+++ b/public/board.html
@@ -28,12 +28,14 @@
       <div class="map-button-row">
         <button id="reset-view-button" class="map-button">Center Map</button>
         <button id="reset-all-button" class="map-button">Clear Map</button>
+        <button id="save-image-button" class="map-button">Save Image</button>
       </div>
       <div id="collapsed-elements">
         <div id="current-color" title="Selected Colour"></div>
         <button id="current-tool" class="tool-button" title="Selected Tool"></button>
         <button id="reset-view-mini" class="map-button" title="Center Map">🎯</button>
         <button id="reset-all-mini" class="map-button" title="Clear Map">🗑️</button>
+        <button id="save-image-mini" class="map-button" title="Save Image">💾</button>
       </div>
       <h3>Colours</h3>
       <div class="color-picker-container">

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -106,7 +106,8 @@ html, body {
 }
 
 #reset-view-mini,
-#reset-all-mini {
+#reset-all-mini,
+#save-image-mini {
   width: 40px;
   height: 40px;
   font-size: 14px;

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -380,6 +380,13 @@ function placeDraggedObject(e) {
   draw();
 }
 
+function saveCanvasImage() {
+  const link = document.createElement('a');
+  link.download = 'tactical-board.png';
+  link.href = state.canvas.toDataURL('image/png');
+  link.click();
+}
+
 function setupContextMenu() {
   const customMenu = document.createElement('div');
   customMenu.id = 'custom-context-menu';
@@ -550,6 +557,10 @@ export function setupEvents() {
       updateDeleteButtonVisibility();
     });
   }
+
+  document.getElementById('save-image-button').addEventListener('click', saveCanvasImage);
+  const miniSave = document.getElementById('save-image-mini');
+  if (miniSave) miniSave.addEventListener('click', saveCanvasImage);
 
   document.querySelectorAll('.draggable-button').forEach(button => {
     button.addEventListener('pointerdown', (e) => {


### PR DESCRIPTION
## Summary
- add a save button to board.html and collapsed view
- style new collapsed icon
- implement canvas export to PNG in events.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848237fb418832388c4d767df8b35aa