### PR TITLE
Add collaborative undo/redo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ tacticalMap
 - **Object Selection** – Select placed objects to move or delete them. A Delete button allows removal on mobile devices.
 - **Pan and Zoom** – Scroll to zoom and drag to pan the map.
 - **Context Menu** – Right click the canvas to quickly switch tools.
+- **Undo/Redo** – Revert the last change or reapply it using toolbar buttons or keyboard shortcuts.
 - **Real‑Time Collaboration** – All drawings, pings and objects are synced between connected clients.
 - **User Colour Management** – The server assigns each user a unique colour and prevents conflicts.
 - **Multi-Room Support** – Each board has an isolated state identified by a unique 4‑digit code returned from the `/host` endpoint.

--- a/public/board.html
+++ b/public/board.html
@@ -28,12 +28,16 @@
       <div class="map-button-row">
         <button id="reset-view-button" class="map-button">Center Map</button>
         <button id="reset-all-button" class="map-button">Clear Map</button>
+        <button id="undo-button" class="map-button">Undo</button>
+        <button id="redo-button" class="map-button">Redo</button>
       </div>
       <div id="collapsed-elements">
         <div id="current-color" title="Selected Colour"></div>
         <button id="current-tool" class="tool-button" title="Selected Tool"></button>
         <button id="reset-view-mini" class="map-button" title="Center Map">🎯</button>
         <button id="reset-all-mini" class="map-button" title="Clear Map">🗑️</button>
+        <button id="undo-mini" class="map-button" title="Undo">↩️</button>
+        <button id="redo-mini" class="map-button" title="Redo">↪️</button>
       </div>
       <h3>Colours</h3>
       <div class="color-picker-container">

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -5,6 +5,10 @@ import { socket, requestColorChange } from './socketHandlers.js';
 const deleteButton = document.getElementById('delete-objects-button');
 const sidePanel = document.getElementById('side-panel');
 const collapseButton = document.getElementById('collapse-button');
+const undoButton = document.getElementById('undo-button');
+const redoButton = document.getElementById('redo-button');
+const undoMini = document.getElementById('undo-mini');
+const redoMini = document.getElementById('redo-mini');
 
 function updateCollapseButton() {
   if (!collapseButton) return;
@@ -486,6 +490,13 @@ export function setupEvents() {
       draw();
       updateDeleteButtonVisibility();
     }
+    if (e.ctrlKey && !e.shiftKey && e.key.toLowerCase() === 'z') {
+      e.preventDefault();
+      socket.emit('undo');
+    } else if (e.ctrlKey && (e.key.toLowerCase() === 'y' || (e.shiftKey && e.key.toLowerCase() === 'z'))) {
+      e.preventDefault();
+      socket.emit('redo');
+    }
     if (e.key === 'Control' && !state.isDragging) {
       state.canvas.style.cursor = 'grab';
     }
@@ -532,6 +543,11 @@ export function setupEvents() {
   state.resetViewButton.addEventListener('click', centerMap);
   const miniCenter = document.getElementById('reset-view-mini');
   if (miniCenter) miniCenter.addEventListener('click', centerMap);
+
+  if (undoButton) undoButton.addEventListener('click', () => socket.emit('undo'));
+  if (redoButton) redoButton.addEventListener('click', () => socket.emit('redo'));
+  if (undoMini) undoMini.addEventListener('click', () => socket.emit('undo'));
+  if (redoMini) redoMini.addEventListener('click', () => socket.emit('redo'));
 
   document.getElementById('reset-all-button').addEventListener('click', () => {
     socket.emit('clearMap');


### PR DESCRIPTION
## Summary
- add undo/redo buttons to the board
- hook undo/redo keys and buttons in event handlers
- track actions on the server and implement `undo` and `redo` socket events
- document the new feature in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684823afef0c8323989528beeee70292