### PR TITLE
Fix map select dropdown sync

### DIFF
--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -41,6 +41,7 @@ export function initSocket() {
     state.pings = serverState.pings;
     state.placedObjects = serverState.objects;
     loadMap(serverState.currentMap);
+    state.mapSelect.value = serverState.currentMap;
     draw();
   });
 
@@ -109,6 +110,7 @@ export function initSocket() {
     state.penPaths = [];
     state.pings = [];
     loadMap(mapName);
+    state.mapSelect.value = mapName;
     draw();
   });
 


### PR DESCRIPTION
## Summary
- ensure map dropdown value updates when joining a room or when another user changes the map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68482d8931d48323a50e3078a021f690